### PR TITLE
Add local embedding retrieval utility and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "openai>=1.107.2",
     "python-dotenv>=1.0.1",
+    "scikit-learn>=1.3.0",
 ]
 
 [tool.uv]

--- a/src/smartmodelrouter/embeddings.py
+++ b/src/smartmodelrouter/embeddings.py
@@ -1,0 +1,64 @@
+"""Utilities for embedding LiveBench prompts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sklearn.feature_extraction.text import HashingVectorizer
+
+from .benchmark import _load_dataset
+
+
+def _get_vectorizer() -> HashingVectorizer:
+    """Return the HashingVectorizer used for embeddings."""
+
+    # Use a small feature space so the embedding is inexpensive.
+    return HashingVectorizer(n_features=128, alternate_sign=False)
+
+
+def embed_problem(model: str, dataset: str, index: int) -> dict[str, Any]:
+    """Return an embedding for a LiveBench problem.
+
+    Parameters
+    ----------
+    model:
+        Identifier for the embedding model. For the local HashingVectorizer the
+        value is informational only but included in the result for consistency.
+    dataset:
+        One of ``"reasoning"``, ``"math"`` or ``"coding"``.
+    index:
+        Zero-based index of the problem in the dataset.
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``model``, ``dataset``, ``index``, ``response`` and
+        ``embedding``.
+    """
+
+    questions = _load_dataset(dataset)
+    try:
+        entry = questions[index]
+    except IndexError as exc:  # pragma: no cover - invalid test usage
+        raise IndexError(
+            f"Problem index {index} out of range for dataset '{dataset}'"
+        ) from exc
+
+    prompt = entry["question"]
+
+    vectorizer = _get_vectorizer()
+    embedding_arr = vectorizer.transform([prompt]).toarray()[0]
+    embedding = list(embedding_arr)
+    response = {"embedding": embedding}
+
+    return {
+        "model": model,
+        "dataset": dataset,
+        "index": index,
+        "response": response,
+        "embedding": embedding,
+    }
+
+
+__all__ = ["embed_problem"]
+

--- a/tests/test_embeddings_e2e.py
+++ b/tests/test_embeddings_e2e.py
@@ -1,0 +1,34 @@
+import httpx
+
+from smartmodelrouter.embeddings import embed_problem
+
+
+def test_embed_problem_end_to_end(monkeypatch):
+    def fail_get(*args, **kwargs):
+        raise httpx.HTTPError("no network")
+
+    monkeypatch.setattr("smartmodelrouter.benchmark.httpx.get", fail_get)
+
+    captured = {}
+
+    class DummyVectorizer:
+        def transform(self, texts):
+            captured["input"] = texts[0]
+
+            class Arr:
+                def toarray(self):
+                    return [[0.5, 0.5]]
+
+            return Arr()
+
+    monkeypatch.setattr(
+        "smartmodelrouter.embeddings._get_vectorizer", lambda: DummyVectorizer()
+    )
+
+    result = embed_problem("test-embed", "reasoning", 0)
+    assert result["model"] == "test-embed"
+    assert result["dataset"] == "reasoning"
+    assert result["index"] == 0
+    assert result["embedding"] == [0.5, 0.5]
+    assert result["response"] == {"embedding": [0.5, 0.5]}
+    assert captured["input"].startswith("If Alice")

--- a/tests/test_embeddings_integration.py
+++ b/tests/test_embeddings_integration.py
@@ -1,0 +1,21 @@
+import httpx
+import pytest
+
+from smartmodelrouter.embeddings import embed_problem
+
+
+@pytest.mark.integration
+def test_embed_problem_integration(monkeypatch):
+    def fail_get(*_args, **_kwargs):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr("smartmodelrouter.benchmark.httpx.get", fail_get)
+
+    result = embed_problem("hashing-embed", "math", 0)
+
+    assert result["model"] == "hashing-embed"
+    assert result["dataset"] == "math"
+    assert result["index"] == 0
+    assert isinstance(result["embedding"], list)
+    assert result["embedding"]
+    assert result["response"] == {"embedding": result["embedding"]}

--- a/tests/test_embeddings_unit.py
+++ b/tests/test_embeddings_unit.py
@@ -1,0 +1,31 @@
+import pytest
+
+from smartmodelrouter.embeddings import embed_problem
+
+
+def test_embed_problem_returns_embedding(monkeypatch):
+    def fake_load(dataset):
+        return [{"question": "What is 2+2?"}]
+
+    monkeypatch.setattr("smartmodelrouter.embeddings._load_dataset", fake_load)
+
+    class DummyVectorizer:
+        def transform(self, texts):
+            assert texts == ["What is 2+2?"]
+
+            class Arr:
+                def toarray(self):
+                    return [[0.1, 0.2]]
+
+            return Arr()
+
+    monkeypatch.setattr(
+        "smartmodelrouter.embeddings._get_vectorizer", lambda: DummyVectorizer()
+    )
+
+    result = embed_problem("emb-model", "math", 0)
+    assert result["model"] == "emb-model"
+    assert result["dataset"] == "math"
+    assert result["index"] == 0
+    assert result["embedding"] == [0.1, 0.2]
+    assert result["response"] == {"embedding": [0.1, 0.2]}


### PR DESCRIPTION
## Summary
- replace OpenRouter embedding calls with a local HashingVectorizer-based `embed_problem`
- cover local embedding helper with unit, integration, and end-to-end tests

## Testing
- `uv run pytest -m "not integration"`
- `uv run pytest -m integration tests/test_embeddings_integration.py`
- `uv run pytest -m integration` *(fails: `test_llm_integration` hung on remote call)*

------
https://chatgpt.com/codex/tasks/task_e_68c76ac867dc832b8991803eb847ae29